### PR TITLE
Lower menu z-index to lower chance of conflict

### DIFF
--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -25,7 +25,7 @@
 				display: block;
 				position: absolute;
 				background: #F5F5F5;
-				z-index: 99999;
+				z-index: 1010;
 				top: 100%;
 				left: 50%;
 				width: 160px;


### PR DESCRIPTION
Related to #7, which while a good idea, is way too high. Lowered it to 1010 to ensure it's above our stuff and hopefully not anything else.
