### PR TITLE
Add siteorigin_panels_is_home() check for origami_gallery()

### DIFF
--- a/inc/gallery.php
+++ b/inc/gallery.php
@@ -13,7 +13,7 @@ function origami_gallery($contents, $attr){
 
 	if(!empty($attr['type']) && $attr['type'] == 'default') return '';
 
-	if(siteorigin_panels_is_home() && empty($attr['ids'])){
+	if( function_exists( 'siteorigin_panels_is_home' ) && siteorigin_panels_is_home() && empty( $attr['ids'] ) ){
 		// Display the default Origami gallery
 		return origami_gallery_default();
 	}


### PR DESCRIPTION
If user isn't using SiteOrigin Page Builder, they won't be able to use the Origami Gallery without error.

```
Fatal error: Call to undefined function siteorigin_panels_is_home() in /wp-
content/themes/origami/inc/gallery.php on line 16
```