### PR TITLE
Fonts: Set Font Display

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -93,7 +93,7 @@ class SiteOrigin_Customizer_CSS_Builder {
 		}
 		$import = array_unique( $import );
 		if ( !empty( $import ) ) {
-			$return .= '@import url(http' . ( is_ssl() ? 's' : '' ) . '://fonts.googleapis.com/css?family=' . implode( '|', $import ) . '); ';
+			$return .= '@import url(http' . ( is_ssl() ? 's' : '' ) . '://fonts.googleapis.com/css?family=' . implode( '|', $import ) . '&display=block); ';
 		}
 
 		foreach ( $this->css as $selector => $rules ) {


### PR DESCRIPTION
This is required to avoid [a Google performance flag](https://web.dev/font-display/). The value is based on https://github.com/siteorigin/so-widgets-bundle/pull/1072/files