### PR TITLE
Only setup FitVids if Enabled in Theme Settings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -188,12 +188,18 @@ if ( ! function_exists( 'origami_enqueue_scripts' ) ) :
 function origami_enqueue_scripts() {
 	wp_enqueue_style( 'origami', get_stylesheet_uri(), array(), SITEORIGIN_THEME_VERSION );
 
+	wp_enqueue_script( 'origami', get_template_directory_uri() . '/js/origami' . SITEORIGIN_THEME_JS_PREFIX . '.js', array( 'jquery' ), SITEORIGIN_THEME_VERSION );
+
 	if ( ! class_exists( 'Jetpack' ) && siteorigin_setting( 'responsive_fitvids' ) ) {
 		wp_enqueue_script( 'fitvids', get_template_directory_uri() . '/js/jquery.fitvids' . SITEORIGIN_THEME_JS_PREFIX . '.js', array( 'jquery' ), '1.0' );
+		wp_localize_script(
+			'origami',
+			'origami', array(
+				'fitvids' => true,
+			)
+		);
 	}
 
-	wp_enqueue_script( 'origami', get_template_directory_uri() . '/js/origami' . SITEORIGIN_THEME_JS_PREFIX . '.js', array( 'jquery' ), SITEORIGIN_THEME_VERSION );
-	
 	wp_enqueue_script( 'flexslider', get_template_directory_uri() . '/js/jquery.flexslider' . SITEORIGIN_THEME_JS_PREFIX . '.js', array( 'jquery' ), '2.1' );
 	wp_enqueue_style( 'flexslider', get_template_directory_uri() . '/css/flexslider.css', array(), '2.0' );
 

--- a/js/origami.js
+++ b/js/origami.js
@@ -7,7 +7,7 @@
 
 jQuery( function( $ ) {
 
-	if ( typeof $.fn.fitVids !== 'undefined' ) {
+	if ( typeof $.fn.fitVids !== 'undefined' && typeof origami !== 'undefined' && typeof origami.fitvids ) {
 		// We use FitVids to scale videos to mobile devices.
 		$( '.featured-video, .content, .content p' ).fitVids();
 	}


### PR DESCRIPTION
Origami version of https://github.com/siteorigin/vantage/pull/391

To test this:
- Install [FitVids for WordPress](https://wordpress.org/plugins/fitvids-for-wordpress/)
- Open js/origami.js and find:

`// We use FitVids to scale videos to mobile devices.`

Add the following to the line prior:

`alert( 123 );`

- Disable FitVids in the theme settings (**Theme Settings > Responsive** and untick **Use FitVids**). Confirm that the alert still happens.
- Apply PR and re-apply the above JS modification.
- Confirm alert doesn't happen, and then re-enable FitVids in theme settings. Confirm alert happens after FitVids is enabled in theme settings.